### PR TITLE
Toggle search input focus and blur on overlay toggle

### DIFF
--- a/src/assets/js/modules/Alpine.data/DOM.js
+++ b/src/assets/js/modules/Alpine.data/DOM.js
@@ -26,6 +26,8 @@ export default () => {
         this.showOverlay = !this.showOverlay;
         if (this.showSearch) {
           this.focusSearch();
+        } else {
+          this.blurSearch();
         }
       },
       openSearch() {
@@ -37,6 +39,12 @@ export default () => {
       closeSearch() {
         this.showSearch = false;
         this.showOverlay = false;
+        this.blurSearch();
+      },
+      blurSearch() {
+        let input = document.querySelector(".pagefind-ui__search-input");
+        input.value = "";
+        input.blur();
       },
       focusSearch() {
         setTimeout(() => {


### PR DESCRIPTION
Add a check to blur the search input when toggling the overlay off and closeSearch function. This ensures that the search input loses focus and is cleared when the search is closed or overlay is hidden.