### PR TITLE
Update schema markup and add organization email

### DIFF
--- a/_data/metadata.js
+++ b/_data/metadata.js
@@ -6,6 +6,7 @@ export default {
   motherShip: "https://freshjuice.dev",
 	language: "en",
 	description: "FreshJuice is a HubSpot CMS theme for developers.",
+  email: "contact@freshjuice.dev",
   social: {
     x: {
       name: "FreshJuiceDev",

--- a/_includes/partials/schema-markup.njk
+++ b/_includes/partials/schema-markup.njk
@@ -4,12 +4,13 @@
   {% if page.url == '/' %}
     <script type="application/ld+json">
       {
-        "@context": "http://schema.org",
+        "@context": "https://schema.org",
         "@type": "Organization",
         "name": "FreshJuice",
         "url": "{{ metadata.url }}",
         "logo": "{{ metadata.url }}/img/logo.png",
         "description": "{{ metadata.description }}",
+        "email": "{{ metadata.email }}",
         "founders": [
           {
             "@type": "Person",
@@ -67,7 +68,7 @@
   {% if layout == 'post' %}
     <script type="application/ld+json">
       {
-        "@context": "http://schema.org",
+        "@context": "https://schema.org",
         "@type": "BlogPosting",
         "mainEntityOfPage": {
           "@type": "WebPage",
@@ -100,7 +101,7 @@
   {% if layout == 'docs' %}
     <script type="application/ld+json">
       {
-        "@context": "http://schema.org",
+        "@context": "https://schema.org",
         "@type": "TechArticle",
         "headline": "{{ title }}",
         "image": "{{ metadata.url }}{% ogImageSource page %}",
@@ -123,7 +124,7 @@
   {% if layout == 'author' %}
     <script type="application/ld+json">
       {
-        "@context": "http://schema.org",
+        "@context": "https://schema.org",
         "@type": "ProfilePage",
         "mainEntity": {
           "@type": "Person",


### PR DESCRIPTION
Switched schema.org URLs to HTTPS for better security. Added organization email to schema markup and updated metadata information accordingly.