### PR TITLE
Enable option to keep closing slashes in minification

### DIFF
--- a/_11ty/transforms.js
+++ b/_11ty/transforms.js
@@ -67,6 +67,7 @@ export default {
           minifyJS: true,
           minifyCSS: true,
           noNewlinesBeforeTagClose: true,
+          keepClosingSlash: true,
           processScripts: ["application/ld+json"],
         });
       }


### PR DESCRIPTION
Added the `keepClosingSlash` option to the HTML minifier configuration to ensure that closing slashes are retained in self-closing tags. This helps maintain compatibility with XHTML and certain XML parsers.