### PR TITLE
Add cheerio to filters and change post content to summary

### DIFF
--- a/_11ty/filters.js
+++ b/_11ty/filters.js
@@ -6,6 +6,7 @@ import {DateTime} from "luxon";
 import { image as gravatarImage } from "gravatar-gen";
 import slugify from "slugify";
 import markdownIt from "markdown-it";
+import * as cheerio from "cheerio";
 
 export default {
 

--- a/_content/feed_json.njk
+++ b/_content/feed_json.njk
@@ -15,7 +15,7 @@ permalink: /feed.json
 			"id": "{{ absolutePostUrl }}",
 			"url": "{{ absolutePostUrl }}",
 			"title": "{{ post.data.title }}",
-			"content_html": {% if post.templateContent %}{{ post.templateContent | transformWithHtmlBase(absolutePostUrl, post.url) | dump | safe }}{% else %}""{% endif %},
+			"summary": "{{ post.data.description }}",
       "image": "{{ metadata.url }}{% ogImageSource post %}",
       "banner_image": "{{ metadata.url }}{% ogImageSource post %}",
 			"date_published": "{{ post.date | dateToRfc3339 }}",

--- a/_content/feed_xml.njk
+++ b/_content/feed_xml.njk
@@ -20,7 +20,7 @@ permalink: /feed.xml
     <author>
       <name>{{ post.data.author | getAuthorData('name') }}</name>
     </author>
-		<content type="html">{%- if eleventy.env.runMode !== "serve" -%}{{ post.templateContent | markdownIt | transformWithHtmlBase(absolutePostUrl, post.url) }}{% endif %}</content>
+		<summary>{{ post.data.description }}</summary>
 	</entry>
 	{%- endfor %}
 </feed>


### PR DESCRIPTION
Integrated the cheerio library into the _11ty/filters.js file for potential future use. Updated feed_json.njk and feed_xml.njk to use post descriptions as summaries instead of full content.