### PR TITLE
Update license to MIT in changelog

### DIFF
--- a/_content/changelog.md
+++ b/_content/changelog.md
@@ -8,7 +8,7 @@ permalink: /changelog/
 
 ***= 2.0.0 - September 20, 2024 =***
 
-- New Licence: MIT
+- Updated license to MIT
 - New Flip Cards Module
 - Big Refactor to Card and Button modules
 - Update styling and layout for some modules


### PR DESCRIPTION
Corrected the license entry in the changelog to accurately reflect the MIT license. This change ensures consistency with the project's licensing terms.