### PR TITLE
Improve metadata handling for title and canonical tags

### DIFF
--- a/_js/Alpine.data/metadata-checker.js
+++ b/_js/Alpine.data/metadata-checker.js
@@ -79,7 +79,13 @@ document.addEventListener("alpine:init", () => {
         returnString = this.escapeHTML(`<!-- HTML Meta Tags -->`);
         for (const [key, value] of Object.entries(data.metadata)) {
           if (value) {
-            returnString += this.escapeHTML(`\n<meta name="${key}" content="${value}">`);
+            if (key === "title") {
+              returnString += this.escapeHTML(`\n<title>${value}</title>`);
+            } else if (key === "canonical") {
+              returnString += this.escapeHTML(`\n<link rel="canonical" href="${value}">`);
+            } else {
+              returnString += this.escapeHTML(`\n<meta name="${key}" content="${value}">`);
+            }
           }
         }
       }


### PR DESCRIPTION
Add specific handling for 'title' and 'canonical' keys in metadata-checker.js by introducing distinct HTML tags: <title> for 'title' and <link rel="canonical"> for 'canonical'. This change ensures proper HTML structure for these metadata elements, enhancing SEO and document readability.