### PR TITLE
Use client-provided User-Agent in metadata checker

### DIFF
--- a/functions/api/metadata-checker/index.js
+++ b/functions/api/metadata-checker/index.js
@@ -26,7 +26,7 @@ export const onRequestPost = async ({ request }) => {
   // Fetch the target URL source code using Axios
   await axios.get(targetUrl, {
     headers: {
-      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
+      "User-Agent": request.headers.get("user-agent") || "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
       "Accept": "text/html"
     }
   })


### PR DESCRIPTION
Replaced the hardcoded User-Agent header with the User-Agent from the client request, defaulting to a standard value if not provided. This change improves compatibility and ensures the server behaves according to the client's context.