### PR TITLE
Update LinkedIn preview styles in metadata checker

### DIFF
--- a/_content/tools/metadata-checker/index.njk
+++ b/_content/tools/metadata-checker/index.njk
@@ -56,7 +56,7 @@ partialScripts:
           <div class="">
             <div>LinkedIn (Light mode)</div>
             <div class="relative overflow-hidden flex items-center w-full grow gap-3 p-3 text-slate-900 bg-slate-100">
-              <div class="aspect-opengraph bg-gray-200 bg-center bg-cover p-8 flex rounded-md justify-center items-center"
+              <div class="shrink-0 aspect-opengraph bg-gray-200 bg-center bg-cover p-8 flex rounded-md justify-center items-center"
                    :style="`background-image: url(${getPreviewImage('linkedin')})`">
               </div>
               <div class="w-full">
@@ -65,10 +65,10 @@ partialScripts:
               </div>
             </div>
           </div>
-          <div class="mt-6">
+          <div class="mt-8">
             <div>LinkedIn (Dark mode)</div>
             <div class="relative overflow-hidden flex items-center w-full grow gap-3 p-3 text-slate-100 bg-slate-700">
-              <div class="aspect-opengraph bg-gray-800 bg-center bg-cover p-8 flex rounded-md justify-center items-center"
+              <div class="shrink-0 aspect-opengraph bg-gray-800 bg-center bg-cover p-8 flex rounded-md justify-center items-center"
                    :style="`background-image: url(${getPreviewImage('linkedin')})`">
               </div>
               <div class="w-full">


### PR DESCRIPTION
Added `shrink-0` class to prevent image distortion in LinkedIn previews for both light and dark modes. Adjusted margin for dark mode section for better spacing consistency.