### PR TITLE
§§Set a minimum width for LinkedIn preview images

### DIFF
--- a/_content/tools/metadata-checker/index.njk
+++ b/_content/tools/metadata-checker/index.njk
@@ -65,7 +65,7 @@ partialScripts:
             <div>LinkedIn (Light mode)</div>
             <div class="relative overflow-hidden flex items-center w-full grow gap-3 p-3 text-slate-900 bg-slate-100">
               <div class="shrink-0 aspect-opengraph bg-gray-200 bg-center bg-cover p-8 flex rounded-md justify-center items-center"
-                   style="width: 122px; height: 64px"
+                   style="width: 122px; min-width: 122px; height: 64px"
                    :style="`background-image: url(${getPreviewImage('linkedin')})`">
               </div>
               <div class="w-full">
@@ -78,7 +78,7 @@ partialScripts:
             <div>LinkedIn (Dark mode)</div>
             <div class="relative overflow-hidden flex items-center w-full grow gap-3 p-3 text-slate-100 bg-slate-700">
               <div class="shrink-0 aspect-opengraph bg-gray-800 bg-center bg-cover p-8 flex rounded-md justify-center items-center"
-                   style="width: 122px; height: 64px"
+                   style="width: 122px; min-width: 122px; height: 64px"
                    :style="`background-image: url(${getPreviewImage('linkedin')})`">
               </div>
               <div class="w-full">


### PR DESCRIPTION
Added a `min-width` property to ensure consistent rendering of LinkedIn preview image containers in both light and dark modes. This resolves potential layout issues where images could shrink below the intended size.